### PR TITLE
商品編集・画像の追加＆削除のdb反映

### DIFF
--- a/app/assets/javascripts/product_image.js
+++ b/app/assets/javascripts/product_image.js
@@ -51,18 +51,22 @@ $(function(){
   });
 
 
-
-  $('#image-box').on('click', '.item-image__operetion--delete', function() {
-    const targetIndex = $(this).parent().data('index');
-    // 該当indexを振られているチェックボックスを取得する
-    const hiddenCheck = $(`input[data-index="${targetIndex}"].hidden-checkbox`);
-    // もしチェックボックスが存在すればチェックを入れる
-    if (hiddenCheck) hiddenCheck.prop('checked', true);
-
-    $(this).parent().remove();
-    $(`img[data-index="${targetIndex}"]`).remove();
-
-    // 画像入力欄が0個にならないようにしておく
-    if ($('img').length == 0) $('#image-box').append(buildFileField(fileIndex[0]));
-  });
+  $(document).on("click", '.item-image__operetion--delete', function(){
+    let productID = $(this).data('index');
+    let imageID = $(this).data('id');
+    console.log(imageID);
+    $.ajax({
+      url: '/products/' + productID + '/image_destroy',
+      type: 'POST',
+      data: {'image_id': imageID,
+            '_method': 'DELETE'},
+      dataType: 'json'
+    })
+    .done(function(data){
+      console.log(data);
+    })
+    .fail(function(){
+      console.log("NG");
+    })
+  })
 });

--- a/app/assets/javascripts/product_image.js
+++ b/app/assets/javascripts/product_image.js
@@ -31,7 +31,38 @@ $(function(){
   });
   $(document).on("click", '.item-image__operetion--delete', function(){
     var target_image = $(this).parent().parent()
-    target_image.remove();
-    file_field.val("");
-  })
+    var target_name = $(target_image).data('image')
+    if(file_field.files.length==1){
+      $('input[type=file]').val(null)
+      dataBox.clearData();
+      console.log(dataBox)
+    }else{
+      $.each(file_field.files, function(i,input){
+        if(input.name==target_name){
+          dataBox.items.remove(i) 
+        }
+      })
+      file_field.files = dataBox.files
+    }
+    target_image.remove()
+    var num = $('.item-image').length
+    $('#image-box__container').show()
+    $('#image-box__container').attr('class', `item-num-${num}`)
+  });
+
+
+
+  $('#image-box').on('click', '.item-image__operetion--delete', function() {
+    const targetIndex = $(this).parent().data('index');
+    // 該当indexを振られているチェックボックスを取得する
+    const hiddenCheck = $(`input[data-index="${targetIndex}"].hidden-checkbox`);
+    // もしチェックボックスが存在すればチェックを入れる
+    if (hiddenCheck) hiddenCheck.prop('checked', true);
+
+    $(this).parent().remove();
+    $(`img[data-index="${targetIndex}"]`).remove();
+
+    // 画像入力欄が0個にならないようにしておく
+    if ($('img').length == 0) $('#image-box').append(buildFileField(fileIndex[0]));
+  });
 });

--- a/app/assets/javascripts/product_image.js
+++ b/app/assets/javascripts/product_image.js
@@ -17,7 +17,7 @@ $(function(){
         var html= `<div class='item-image' data-image="${file.name}">
                     <div class=' item-image__content'>
                       <div class='item-image__content--icon'>
-                        <img src=${src} width="114" height="80" >
+                        <img src=${src} width="114" height="80" data={index: index}>
                       </div>
                     </div>
                     <div class='item-image__operetion'>
@@ -51,22 +51,23 @@ $(function(){
   });
 
 
-  $(document).on("click", '.item-image__operetion--delete', function(){
-    let productID = $(this).data('index');
-    let imageID = $(this).data('id');
-    console.log(imageID);
-    $.ajax({
-      url: '/products/' + productID + '/image_destroy',
-      type: 'POST',
-      data: {'image_id': imageID,
-            '_method': 'DELETE'},
-      dataType: 'json'
-    })
-    .done(function(data){
-      console.log(data);
-    })
-    .fail(function(){
-      console.log("NG");
-    })
+  // $(document).on("click", '.item-image__operetion--delete', function(){
+  //   let productID = $(this).data('index');
+  //   let imageID = $(this).data('id');
+  //   $.ajax({
+  //     url: '/products/' + productID + '/image_destroy',
+  //     type: 'POST',
+  //     data: {'image_id': imageID,
+  //           '_method': 'DELETE'},
+  //     dataType: 'json'
+  //   })
+  // });
+  $(document).on('click', '.item-image__operetion--delete', function() {
+    const targetIndex = $(this).parent().data('index')
+    const hiddenCheck = $(`input[data-index="${targetIndex}"].hidden-destroy`);
+    console.log(hiddenCheck);
+    if (hiddenCheck) hiddenCheck.prop('checked', true);
+    $(this).parent().remove();
+    $(`img[data-index="${targetIndex}"]`).remove();
   })
 });

--- a/app/assets/javascripts/product_image.js
+++ b/app/assets/javascripts/product_image.js
@@ -30,12 +30,17 @@ $(function(){
     });
   });
   $(document).on("click", '.item-image__operetion--delete', function(){
-    var target_image = $(this).parent().parent()
-    var target_name = $(target_image).data('image')
+    const targetIndex = $(this).parent().find('.item-image__operetion--delete').data('index');
+    const hiddenCheck = $(`input[data-index="${targetIndex}"].hidden-destroy`);
+    if (hiddenCheck) hiddenCheck.prop('checked', true);
+    $(this).parent().remove();
+    $(`img[data-index="${targetIndex}"]`).remove();
+
+    var target_image = $(this).parent().parent();
+    var target_name = $(target_image).data('image');
     if(file_field.files.length==1){
       $('input[type=file]').val(null)
       dataBox.clearData();
-      console.log(dataBox)
     }else{
       $.each(file_field.files, function(i,input){
         if(input.name==target_name){
@@ -44,30 +49,9 @@ $(function(){
       })
       file_field.files = dataBox.files
     }
-    target_image.remove()
-    var num = $('.item-image').length
+    target_image.remove();
+    var num = $('.item-image').length;
     $('#image-box__container').show()
     $('#image-box__container').attr('class', `item-num-${num}`)
   });
-
-
-  // $(document).on("click", '.item-image__operetion--delete', function(){
-  //   let productID = $(this).data('index');
-  //   let imageID = $(this).data('id');
-  //   $.ajax({
-  //     url: '/products/' + productID + '/image_destroy',
-  //     type: 'POST',
-  //     data: {'image_id': imageID,
-  //           '_method': 'DELETE'},
-  //     dataType: 'json'
-  //   })
-  // });
-  $(document).on('click', '.item-image__operetion--delete', function() {
-    const targetIndex = $(this).parent().data('index')
-    const hiddenCheck = $(`input[data-index="${targetIndex}"].hidden-destroy`);
-    console.log(hiddenCheck);
-    if (hiddenCheck) hiddenCheck.prop('checked', true);
-    $(this).parent().remove();
-    $(`img[data-index="${targetIndex}"]`).remove();
-  })
 });

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -119,7 +119,7 @@ class ProductsController < ApplicationController
       :judgment,
       :category_id,
       :cost, :days, :prefecture_id,
-      images_attributes: [{image: [:image]}, :product_id, :id],
+      images_attributes: [{image: [:image]}, :_destroy, :product_id, :id],
       category_attributes: [:name], 
       brand_attributes: [:name]
     ).merge(

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -68,11 +68,6 @@ class ProductsController < ApplicationController
     @category_grandchildren = Category.find(params[:child_id]).children
   end
 
-  def image_destroy
-    @image = Image.find(params[:image_id])
-    @image.destroy
-  end
-
   private
 
   def category_edit

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -50,6 +50,7 @@ class ProductsController < ApplicationController
 
   def update
     @product = Product.find(params[:id])
+    binding.pry
     if @product.update(product_update_params)
       redirect_to product_path(@product)
     else
@@ -113,7 +114,7 @@ class ProductsController < ApplicationController
       :judgment,
       :category_id,
       :cost, :days, :prefecture_id,
-      images_attributes: [{image: []}, :product_id, :id, :image],
+      images_attributes: [{image: [:image]}, :product_id, :id],
       category_attributes: [:name], 
       brand_attributes: [:name]
     ).merge(

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -50,10 +50,10 @@ class ProductsController < ApplicationController
 
   def update
     @product = Product.find(params[:id])
-    binding.pry
     if @product.update(product_update_params)
       redirect_to product_path(@product)
     else
+      flash[:error] = "入力に誤りがあります。もう一度入力してください。"
       redirect_to edit_product_path(@product)
     end
   end
@@ -66,6 +66,11 @@ class ProductsController < ApplicationController
  # 子カテゴリーが選択された後に動くアクション
   def get_category_grandchildren
     @category_grandchildren = Category.find(params[:child_id]).children
+  end
+
+  def image_destroy
+    @image = Image.find(params[:image_id])
+    @image.destroy
   end
 
   private

--- a/app/views/products/edit.html.haml
+++ b/app/views/products/edit.html.haml
@@ -20,16 +20,15 @@
             .item-image{"data-image" => "${file.name}"}
               .item-image__content
                 .item-image__content--icon
-                  = image_tag image.image.to_s, size: "114x80", data: {index: index}
+                  = image_tag image.image.to_s, size: "114x80", data: {index: index}, name: "product[images_attributes][image][image]"
               .item-image__operetion
-                = f.hidden_field :image, multiple: true, value: image.image.to_s,name: "product[images_attributes][0..9][image]"
+                -# = f.hidden_field :image, multiple: true, value: image.image.to_s, name: "product[images_attributes][0..9][image]"
                 .item-image__operetion--delete{data:{index: index}}
                   削除
         .item-num-0#image-box__container
-          = f.fields_for :images, @images do |i|
+          = f.fields_for :images do |i|
             .input-area
-              = i.file_field :image, multiple: true, type: 'file', name: "product[images_attributes][0..9][image]", style: "display:none", id:"img-file"
-              = i.check_box :_destroy, data:{ index: i.index }, class: "check-box"
+              = i.file_field :image, multiple: true, type: 'file', name: "product[images_attributes][image][image]", style: "display:none", id:"img-file"
               
     .border_bottom
     .selle_contents__content

--- a/app/views/products/edit.html.haml
+++ b/app/views/products/edit.html.haml
@@ -22,13 +22,14 @@
                 .item-image__content--icon
                   = image_tag image.image.to_s, size: "114x80", data: {index: index}, name: "product[images_attributes][image][image]"
               .item-image__operetion
-                .item-image__operetion--delete{data:{index: @product.id, id: image.id}}
+                .item-image__operetion--delete{data:{index: index}}
                   削除
+                
         .item-num-0#image-box__container
           = f.fields_for :images do |i|
             .input-area
               = i.file_field :image, multiple: true, type: 'file', name: "product[images_attributes][image][image]", style: "display:none", id:"img-file"
-              = i.check_box :_destroy, data:{ index: i.index }, class: 'hidden-destroy'
+              = i.check_box :_destroy, data:{ index: i.index }, style: 'display:none', class: 'hidden-destroy'
               
     .border_bottom
     .selle_contents__content

--- a/app/views/products/edit.html.haml
+++ b/app/views/products/edit.html.haml
@@ -22,13 +22,13 @@
                 .item-image__content--icon
                   = image_tag image.image.to_s, size: "114x80", data: {index: index}, name: "product[images_attributes][image][image]"
               .item-image__operetion
-                -# = f.hidden_field :image, multiple: true, value: image.image.to_s, name: "product[images_attributes][0..9][image]"
                 .item-image__operetion--delete{data:{index: @product.id, id: image.id}}
                   削除
         .item-num-0#image-box__container
           = f.fields_for :images do |i|
             .input-area
               = i.file_field :image, multiple: true, type: 'file', name: "product[images_attributes][image][image]", style: "display:none", id:"img-file"
+              = i.check_box :_destroy, data:{ index: i.index }, class: 'hidden-destroy'
               
     .border_bottom
     .selle_contents__content

--- a/app/views/products/edit.html.haml
+++ b/app/views/products/edit.html.haml
@@ -23,7 +23,7 @@
                   = image_tag image.image.to_s, size: "114x80", data: {index: index}, name: "product[images_attributes][image][image]"
               .item-image__operetion
                 -# = f.hidden_field :image, multiple: true, value: image.image.to_s, name: "product[images_attributes][0..9][image]"
-                .item-image__operetion--delete{data:{index: index}}
+                .item-image__operetion--delete{data:{index: @product.id, id: image.id}}
                   削除
         .item-num-0#image-box__container
           = f.fields_for :images do |i|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
       get 'get_category_grandchildren', defaults: { format: 'json' }
     end
     member do
+      delete 'image_destroy', defaults: { format: 'json' }
       get 'get_category_children', defaults: { format: 'json' }
       get 'get_category_grandchildren', defaults: { format: 'json' }
     end


### PR DESCRIPTION
#What
商品編集ページで、追加した画像がDBにデータ追加されるように実装した。
また、削除ボタンを押した画像が、更新後にDBから削除されるように実装した。
(削除ボタンを押したら隠れているチェックボックスにチェックがつき、チェックがついている画像を削除するようにJSで記述した)

#Why
フリマアプリにおいて、出品した商品を編集する機能は必須のため。
画像の追加・削除ができることが重要。

https://gyazo.com/b8c1c460a3a4566045d81dcb23e8e4b1
https://gyazo.com/d293acd1040aca955a1fb4362a5184b3
https://gyazo.com/4239a79a9e6951e9e84bf5d820bdc8d4
https://gyazo.com/92c63c4b7084a44662670142ceb68a64
https://gyazo.com/9d7087fd1c76c3d9c3b1bffdf1440a4a