### PR TITLE
[WIP]top,userマイページ　出品画像表示

### DIFF
--- a/app/views/template/_object.html.haml
+++ b/app/views/template/_object.html.haml
@@ -1,7 +1,7 @@
 = link_to product_path(p.id) do
   .object
     .image
-      = image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/13/a007.png"
+      = image_tag p.images.first.image.to_s
     .parts 
       商品名 : 
       = p.name

--- a/app/views/template/_products.html.haml
+++ b/app/views/template/_products.html.haml
@@ -4,7 +4,7 @@
       = link_to product_path(p) do
         .product
           .image
-            %img(src="https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/13/a007.png" alt="")/
+            = image_tag p.images.first.image.to_s
           .info
             %p 
               = p.name 


### PR DESCRIPTION
#What
- トップ画面とユーザーマイページに商品の画像を一枚だけ表示させる
#Why
- 画像の表示がないと機能として不十分なため。